### PR TITLE
update docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,20 +898,18 @@ http://localhost:3000/download?name=fileName
 # Docker
 [:arrow_heading_up:](#api-overview)
 
-Simply build with `docker build -t xmysql .` and run with `docker run -p 3000:3000 -d xmysql`
+Simply run with `docker run -p 3000:3000 -d markuman/xmysql`
 
 The best way for testing is to run mysql in a docker container too and create a docker network, so that `xmysql` can access the `mysql` container with a name from docker network.
 
 1. Create network 
     * `docker network create mynet`
 2. Start mysql with docker name `some-mysql` and bind to docker network `mynet`
-    * `docker run --name some-mysql -p 3306:3306 --net mynet -e MYSQL_ROOT_PASSWORD=password -d mysql`
-3. build xmysql container (if not done yet)
-    * `docker build -t xmysql .`
-4. run xmysql and set env variable for `some-mysql` from step 2
-    * `docker run -p 3000:3000 -d -e DATABASE_HOST=some-mysql --net mynet xmysql`
+    * `docker run --name some-mysql -p 3306:3306 --net mynet -e MYSQL_ROOT_PASSWORD=password -d markuman/mysql`
+3. run xmysql and set env variable for `some-mysql` from step 2
+    * `docker run -p 3000:3000 -d -e DATABASE_HOST=some-mysql --net mynet markuman/xmysql`
 
-You can also pass the environment variables to a file and use them as an option with docker like `docker run --env-file ./env.list -p 3000:3000 --net mynet -d xmysql`
+You can also pass the environment variables to a file and use them as an option with docker like `docker run --env-file ./env.list -p 3000:3000 --net mynet -d markuman/xmysql`
 
 environment variables which can be used:
 

--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,8 @@
-FROM mhart/alpine-node:latest
+FROM alpine:3.7
+
+RUN apk --update --no-cache add \
+	nodejs \
+	nodejs-npm
 
 RUN mkdir -p /usr/src/{app,bin,lib}
 WORKDIR /usr/src/app
@@ -6,6 +10,8 @@ WORKDIR /usr/src/app
 # only install production deps to keep image small
 COPY package.json /usr/src/app
 RUN npm install --production
+
+RUN apk del nodejs-npm
 
 COPY index.js /usr/src/app
 COPY bin/ /usr/src/app/bin


### PR DESCRIPTION
update docker image. 
using now default alpine 3.7 image (comes with nodejs 8.9.1). It's 15 MB smaller now.