### PR TITLE
Fixing pagination issue when using _p & _size

### DIFF
--- a/lib/xsql.js
+++ b/lib/xsql.js
@@ -197,7 +197,7 @@ class Xsql {
     }
 
     if ('_p' in reqParams && parseInt(reqParams._p) > 0) {
-      reqParams._index = (parseInt(reqParams._p) - 1) * reqParams._len + 1;
+      reqParams._index = (parseInt(reqParams._p) - 1) * reqParams._len;
     }
 
     //console.log(reqParams._index, reqParams._len);


### PR DESCRIPTION
When using _p ang _size query params in URL, the first row is skipped.

Example:
_p = 1 & _size = 20
reqParams._index will be = (1 - 1) * 20 + 1 = 1; 
Generated SQL will be SELECT * FROM ? LIMIT 1,20. This SQL skips first element in the table
Correct SQL that should be generated is SELECT * FROM ? LIMIT 0,20