### PR TITLE
Fixed version bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,12 +11,14 @@ const Xapi = require('./lib/xapi.js');
 const cmdargs = require('./lib/util/cmd.helper.js');
 const cluster = require('cluster');
 const numCPUs = require('os').cpus().length;
+const { version } = require('./package.json');
 
 
 
 function startXmysql(sqlConfig) {
   /**************** START : setup express ****************/
   let app = express();
+  app.set('version', version);
   app.use(morgan('tiny'));
   app.use(cors());
   app.use(bodyParser.json());

--- a/lib/util/cmd.helper.js
+++ b/lib/util/cmd.helper.js
@@ -1,7 +1,6 @@
 'use strict';
 const program = require('commander');
 const colors = require('colors');
-const pkginfo = require('pkginfo')(module);
 const maxCpus = require('os').cpus().length;
 
 

--- a/lib/xapi.js
+++ b/lib/xapi.js
@@ -4,7 +4,6 @@ var Xsql = require('./xsql.js');
 var Xctrl = require('./xctrl.js');
 var multer = require('multer');
 const path = require('path');
-const pkginfo = require('pkginfo')(module);
 
 const v8 = require('v8'),
   os = require('os');
@@ -444,7 +443,7 @@ class Xapi {
 
     let version = {};
 
-    version['Xmysql'] = pkginfo.version;
+    version['Xmysql'] = this.app.get('version');
     version['mysql'] = await this.getMysqlHealth();
     version['node'] = process.versions.node;
     res.json(version);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xmysql",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -621,9 +621,9 @@
       }
     },
     "nan": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
+      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
       "dev": true
     },
     "negotiator": {
@@ -673,11 +673,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
-    },
-    "pkginfo": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
-      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8="
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -824,9 +819,9 @@
       "dev": true
     },
     "sleep": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/sleep/-/sleep-5.1.1.tgz",
-      "integrity": "sha1-h4+h1E0I7rDyb7IBjvhinrGjq5Q=",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/sleep/-/sleep-5.2.3.tgz",
+      "integrity": "sha512-vC05N1XqgIiPIj6tEq7wt0R32aTycJv4Ymo/jwSEp2PkeU1GCJ1tkl+RdYZEo7Gjebq8QQuhFuEe7vsyVGlFRA==",
       "dev": true,
       "requires": {
         "nan": ">=2.5.1"

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "express": "^4.16.1",
     "morgan": "^1.9.0",
     "multer": "^1.3.0",
-    "mysql": "^2.15.0",
-    "pkginfo": "^0.4.1"
+    "mysql": "^2.15.0"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -8,6 +8,7 @@ var whereClause = require('../lib/util/whereClause.helper.js')
 var should = require('should');
 var request = require('supertest')
 const cmdargs = require('../lib/util/cmd.helper.js');
+const { version } = require('../package.json');
 
 var args = {}
 var app = {}
@@ -33,7 +34,7 @@ describe('xmysql : tests', function () {
     mysqlPool = mysql.createPool(args)
 
     app = express()
-    //app.use(morgan('tiny'))
+    app.set('version', version)
     app.use(bodyParser.json())
     app.use(bodyParser.urlencoded({
       extended: true
@@ -1894,7 +1895,7 @@ describe('xmysql : tests', function () {
           return done(err);
         }
 
-        res.body['Xmysql'].should.not.equals("");
+        res.body['Xmysql'].should.equals(version);
         res.body['mysql'].should.not.equals("");
         res.body['node'].should.not.equals("");
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -8,7 +8,6 @@ var whereClause = require('../lib/util/whereClause.helper.js')
 var should = require('should');
 var request = require('supertest')
 const cmdargs = require('../lib/util/cmd.helper.js');
-const pkginfo = require('pkginfo')(module);
 
 var args = {}
 var app = {}
@@ -1895,7 +1894,7 @@ describe('xmysql : tests', function () {
           return done(err);
         }
 
-        res.body['Xmysql'].should.equals(pkginfo.version);
+        res.body['Xmysql'].should.not.equals("");
         res.body['mysql'].should.not.equals("");
         res.body['node'].should.not.equals("");
 


### PR DESCRIPTION
The current implementation is broken - the `_version` endpoint returns the version of the package `pkginfo` (0.4.1) instead of that of this package (0.4.9).

(Calling `const pkginfo = require('pkginfo')(module);` exposes the info on `module.exports`, not on the variable `pkginfo`.)