### PR TITLE
Made pagination start at p=0 instead of p=1

### DIFF
--- a/lib/xsql.js
+++ b/lib/xsql.js
@@ -217,7 +217,7 @@ class Xsql {
 
 
     if ('_p' in reqParams && parseInt(reqParams._p) > 0) {
-      reqParams._index = (parseInt(reqParams._p) - 1) * reqParams._len;
+      reqParams._index = parseInt(reqParams._p) * reqParams._len;
     }
 
     //console.log(reqParams._index, reqParams._len);


### PR DESCRIPTION
The current implementation of the pagination starts at _p=1 (_p=0 yields the same result). This is counter-intuitive. Pagination should start at _p=0.

This PR fixes that.