### PR TITLE
Adds support for unix socketPath

### DIFF
--- a/lib/util/cmd.helper.js
+++ b/lib/util/cmd.helper.js
@@ -21,6 +21,7 @@ program
   .option('-r, --ipAddress <n>', 'IP interface of your server / localhost by default')
   .option('-n, --portNumber <n>', 'port number for app / 3000 by default')
   .option('-o, --port <n>', 'port number for mysql / 3306 by default')
+  .option('-S, --socketPath <n>', 'unix socket path / not used by default')
   .option('-s, --storageFolder <n>', 'storage folder / current working dir by default / available only with local')
   .option('-i, --ignoreTables <n>', 'comma separated table names to ignore')
   .option('-a, --apiPrefix <n>', 'api url prefix / "/api/" by default')
@@ -61,6 +62,7 @@ exports.handle = program => {
   program.user = program.user || 'root';
   program.password = program.password || '';
   program.host = program.host || 'localhost';
+  program.socketPath = program.socketPath || '';
   program.storageFolder = program.storageFolder || process.cwd()
   program.apiPrefix = program.apiPrefix || '/api/'
   program.readOnly = program.readOnly || false;


### PR DESCRIPTION
Some environments (like google cloud) require connection to be established via unix sockets.
This PR adds support for mysql's unix socket connection.

Example:

```
xmysql -u $DB_USER -d $DB_NAME -p $DB_PASSWORD -S $DB_SOCKET_PATH 
```